### PR TITLE
Field side filter, for ball and robots

### DIFF
--- a/crates/crabe_filter/src/data.rs
+++ b/crates/crabe_filter/src/data.rs
@@ -21,7 +21,7 @@ pub type TrackedRobotMap<T> = HashMap<u8, TrackedRobot<T>>;
 pub struct FilterData {
     pub allies: TrackedRobotMap<AllyInfo>,
     pub enemies: TrackedRobotMap<EnemyInfo>,
-    pub ball: TrackedBall,
+    pub ball: Option<TrackedBall>,
     pub geometry: CamGeometry,
 }
 

--- a/crates/crabe_filter/src/filter.rs
+++ b/crates/crabe_filter/src/filter.rs
@@ -1,6 +1,7 @@
 pub mod inactive;
 pub mod passthrough;
 pub mod velocity_acceleration;
+pub mod field_side;
 
 use crate::data::FilterData;
 use crabe_framework::data::world::World;

--- a/crates/crabe_filter/src/filter/field_side.rs
+++ b/crates/crabe_filter/src/filter/field_side.rs
@@ -1,0 +1,41 @@
+use crabe_framework::data::world::{Robot, World};
+use crate::data::{FilterData, TrackedBall, TrackedRobotMap};
+use crate::FieldSide;
+use crate::filter::Filter;
+use crate::post_filter::PostFilter;
+
+pub struct FieldSideFilter {
+    field_side: FieldSide,
+}
+
+impl FieldSideFilter {
+    pub fn new(field_side: FieldSide) -> FieldSideFilter {
+        FieldSideFilter { field_side }
+    }
+
+    fn filter_robots_by_side<T>(tracked_robots: &mut TrackedRobotMap<T>, field_side: &FieldSide) {
+        tracked_robots.retain(|_id, robot| {
+            match field_side {
+                FieldSide::Positive => robot.data.pose.position.x.is_sign_positive(),
+                FieldSide::Negative => robot.data.pose.position.x.is_sign_negative()
+            }
+        });
+    }
+
+    fn filter_ball_by_side(tracked_ball: &mut Option<TrackedBall>, field_side: &FieldSide) {
+        *tracked_ball = tracked_ball.take().filter(|ball| {
+            match field_side {
+                FieldSide::Positive => ball.data.position.x.is_sign_positive(),
+                FieldSide::Negative => ball.data.position.x.is_sign_negative()
+            }
+        })
+    }
+}
+
+impl Filter for FieldSideFilter {
+    fn step(&mut self, filter_data: &mut FilterData, _world: &World) {
+        Self::filter_robots_by_side(&mut filter_data.allies, &self.field_side);
+        Self::filter_robots_by_side(&mut filter_data.enemies, &self.field_side);
+        Self::filter_ball_by_side(&mut filter_data.ball, &self.field_side);
+    }
+}

--- a/crates/crabe_filter/src/filter/passthrough.rs
+++ b/crates/crabe_filter/src/filter/passthrough.rs
@@ -40,6 +40,8 @@ impl Filter for PassthroughFilter {
     fn step(&mut self, filter_data: &mut FilterData, _world: &World) {
         robot_passthrough(filter_data.allies.iter_mut());
         robot_passthrough(filter_data.enemies.iter_mut());
-        ball_passthrough(&mut filter_data.ball);
+
+        let tracked_ball = filter_data.ball.get_or_insert(Default::default());
+        ball_passthrough(tracked_ball);
     }
 }

--- a/crates/crabe_filter/src/filter/velocity_acceleration.rs
+++ b/crates/crabe_filter/src/filter/velocity_acceleration.rs
@@ -45,7 +45,9 @@ impl Filter for VelocityAccelerationFilter {
     fn step(&mut self, filter_data: &mut FilterData, world: &World) {
         update_robot_vel_accel(&mut filter_data.allies, &world.allies_bot);
         if let Some(ball) = world.ball.as_ref() {
-            update_ball_vel_accel(&mut filter_data.ball, ball);
+            if let Some(tracked_ball) = &mut filter_data.ball {
+                update_ball_vel_accel(tracked_ball, ball);
+            }
         }
     }
 }

--- a/crates/crabe_filter/src/lib.rs
+++ b/crates/crabe_filter/src/lib.rs
@@ -15,14 +15,25 @@ use crate::post_filter::robot::RobotFilter;
 use crate::post_filter::PostFilter;
 use crate::pre_filter::vision::VisionFilter;
 use crate::pre_filter::PreFilter;
-use clap::Args;
+use clap::{Args, ValueEnum};
 use crabe_framework::component::{Component, FilterComponent};
 use crabe_framework::config::CommonConfig;
 use crabe_framework::data::input::InboundData;
 use crabe_framework::data::world::{TeamColor, World};
+use filter::velocity_acceleration::VelocityAccelerationFilter;
+use crate::filter::field_side::FieldSideFilter;
 
 #[derive(Args)]
-pub struct FilterConfig {}
+pub struct FilterConfig {
+    #[arg(long)]
+    field_side: Option<FieldSide>
+}
+
+#[derive(Debug, ValueEnum, Clone)]
+pub enum FieldSide {
+    Positive,
+    Negative
+}
 
 pub struct FilterPipeline {
     pub pre_filters: Vec<Box<dyn PreFilter>>,
@@ -33,18 +44,28 @@ pub struct FilterPipeline {
 }
 
 impl FilterPipeline {
-    pub fn with_config(_config: FilterConfig, common_config: &CommonConfig) -> Self {
+    pub fn with_config(config: FilterConfig, common_config: &CommonConfig) -> Self {
+        let mut pre_filters: Vec<Box<dyn PreFilter>> = vec![Box::new(VisionFilter::new())];
+        let mut filters: Vec<Box<dyn Filter>> = vec![
+            Box::new(PassthroughFilter),
+            Box::new(VelocityAccelerationFilter),
+            Box::<InactiveFilter>::default(),
+        ];
+
+        if let Some(field_side) = config.field_side {
+            filters.push(Box::new(FieldSideFilter::new(field_side)))
+        }
+
+        let mut post_filters: Vec<Box<dyn PostFilter>> = vec![
+            Box::new(RobotFilter),
+            Box::new(GeometryFilter),
+            Box::new(BallFilter),
+        ];
+
         Self {
-            pre_filters: vec![Box::new(VisionFilter::new())],
-            filters: vec![
-                Box::new(PassthroughFilter),
-                Box::<InactiveFilter>::default(),
-            ],
-            post_filters: vec![
-                Box::new(RobotFilter),
-                Box::new(GeometryFilter),
-                Box::new(BallFilter),
-            ],
+            pre_filters,
+            filters,
+            post_filters,
             filter_data: FilterData {
                 allies: Default::default(),
                 enemies: Default::default(),

--- a/crates/crabe_filter/src/post_filter/ball.rs
+++ b/crates/crabe_filter/src/post_filter/ball.rs
@@ -6,6 +6,18 @@ pub struct BallFilter;
 
 impl PostFilter for BallFilter {
     fn step(&mut self, filter_data: &FilterData, world: &mut World) {
-        world.ball = Some(filter_data.ball.data.clone());
+        let ball = filter_data.ball.as_ref().map(|tracked_ball| {
+            let mut ball = tracked_ball.data.clone();
+            if world.data.positive_half == world.team_color {
+                ball.position.x = -ball.position.x;
+                ball.position.y = -ball.position.y;
+            }
+
+            ball
+        });
+
+        if ball.is_some() {
+            world.ball = ball;
+        } 
     }
 }

--- a/crates/crabe_filter/src/pre_filter/vision.rs
+++ b/crates/crabe_filter/src/pre_filter/vision.rs
@@ -96,7 +96,7 @@ mod detection {
 
         pub struct BallDetectionInfo<'a> {
             pub detected: &'a [SslDetectionBall],
-            pub tracked: &'a mut TrackedBall,
+            pub tracked: &'a mut Option<TrackedBall>,
         }
 
         pub fn detect_balls(detection: &mut BallDetectionInfo, frame: &FrameInfo) {
@@ -110,7 +110,7 @@ mod detection {
                 confidence: b.confidence as f64,
             });
 
-            detection.tracked.packets.extend(ball_packets);
+            detection.tracked.get_or_insert(Default::default()).packets.extend(ball_packets);
         }
     }
 

--- a/crates/crabe_framework/src/data/world/team.rs
+++ b/crates/crabe_framework/src/data/world/team.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The `TeamColor` enum represents the color of a team in the SSL game, either blue or yellow.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum TeamColor {
     Blue,


### PR DESCRIPTION
# Field side filter
## Addition
New argument to launch the program with : `--field-side`
Possible values :
- `--field-side=positive`
- `--field-side=negative`

Only the selected side will be seen by the software, meaning that robots and balls on the opposite side will be considered as non-existent.
 
## Description
_copy paste from first commit_

During competition, Division B fields are divided in two halves so that two teams can use
the field at the same time. Some teams cannot change their colors or have their own ball, this filter
fixes the problem by only watching one half of the field.

This commit is the result of squashing the following commits from other branches (from most recent to oldest) :

> commit 3dacef92963264e109bd8e35871e3ea681f1f46a
> Author: Jossl123 <jossl1.gau@gmail.com>
> Date:   Wed Jul 5 13:32:10 2023 +0200
> 
>     ball filter side preventing None position
>     Related PR : https://github.com/NAMeC-team/CRAbE/pull/25
> 
> commit 891d199acb2d3ccd47c9193e2f4636b1673c83bf
> Author: Benjamin Chew <benjaminchew4@gmail.com>
> Date:   Wed Jul 5 10:36:08 2023 +0200
> 
>     feat: added field side filter for the ball
>     Related PR : https://github.com/NAMeC-team/CRAbE/pull/21
> 
> commit 00adb6c41abce862173ed1fcb9515e8905a95b36
> Author: Benjamin Chew <benjaminchew4@gmail.com>
> Date:   Tue Jul 4 12:51:10 2023 +0200
> 
>     feat: added field side filter
>     Related PR : https://github.com/NAMeC-team/CRAbE/pull/11
> 
> Co-authored-by: Benjamin Chew <benjaminchew4@gmail.com>
> Co-authored-by: Jossl123 <jossl1.gau@gmail.com>

## Testing
### Robot filtering
Launch the program with (at least) the following
`cargo run -- --field-side=positive`
Check that robot does not move if it is in the negative side

Relaunch the program with `--field-side=negative` and check that robot 0 starts moving, then suddenly stops once it crosses the middle line

### Ball filtering
In `crabe_filter/src/post_filter/ball.rs`, add a `dbg!(&ball)` call at line 18.
Using similar parameters as mentioned before, place the ball on the positive side, start with `--filter-side=negative`, and checks that the debug call displays a None value for the ball. Putting the ball in the middle might make it seen by the software, so place it properly on one side or the other. Test the opposite side as well