### PR TITLE
fix: manual free kick command properly handled

### DIFF
--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -95,7 +95,7 @@ impl GameControllerPostFilter {
             dbg!(&referee.designated_position);
             dbg!(&referee.current_action_time_remaining);
 
-            self.update_latest_state_data(referee, );
+            self.update_latest_state_data(referee);
 
             new_state = self.resolve_branch(&referee.command)
                 .process_state(world,

--- a/crates/crabe_filter/src/post_filter/game_controller.rs
+++ b/crates/crabe_filter/src/post_filter/game_controller.rs
@@ -38,9 +38,18 @@ impl GameControllerPostFilter {
         }
         self.state_data.last_ref_cmd = referee.command;
 
-        if let Some(designated_pos) = referee.designated_position {
-            self.state_data.last_designated_pos = designated_pos / 1000.;
-        }
+        match self.state_data.prev_ref_cmd {
+            RefereeCommand::PrepareKickoff(_)
+            | RefereeCommand::PreparePenalty(_)
+            | RefereeCommand::DirectFree(_) => {
+                self.state_data.last_designated_pos = None
+            }
+            _ => {
+                if let Some(designated_pos) = referee.designated_position {
+                    self.state_data.last_designated_pos = Some(designated_pos / 1000.);
+                }
+            }
+       }
     }
 }
 
@@ -86,7 +95,7 @@ impl GameControllerPostFilter {
             dbg!(&referee.designated_position);
             dbg!(&referee.current_action_time_remaining);
 
-            self.update_latest_state_data(referee);
+            self.update_latest_state_data(referee, );
 
             new_state = self.resolve_branch(&referee.command)
                 .process_state(world,

--- a/crates/crabe_framework/src/data/state_handler.rs
+++ b/crates/crabe_framework/src/data/state_handler.rs
@@ -53,7 +53,7 @@ pub struct GameStateData {
     /// The most recent referee command issued
     pub last_ref_cmd: RefereeCommand,
     /// Latest designated position provided by the referee
-    pub last_designated_pos: Point2<f64>,
+    pub last_designated_pos: Option<Point2<f64>>,
     /// Last saved score of the ally team
     pub ally_score: u32,
     /// Last saved score of the enemy team
@@ -66,7 +66,7 @@ impl Default for GameStateData {
             kicked_off_once: false,
             prev_ref_cmd: RefereeCommand::Halt,
             last_ref_cmd: RefereeCommand::Halt,
-            last_designated_pos: Point2::new(0., 0.),
+            last_designated_pos: Some(Point2::new(0., 0.)),
             ally_score: 0,
             enemy_score: 0,
         }


### PR DESCRIPTION
first free kick of the match was always handled correctly, but if the GC operator were to trigger a free kick with no designated position, the software would skip it immediately. this behaviour has been fixed

to test this PR :
- Start the software + GC
- Display the current state
- Check that the following set of commands in the GC leads to a free kick state in CRAbE
`Start a new game -> Resume -> Kickoff -> Normal start -> Stop -> Free kick (any team)`