### PR TITLE
Goal overshoot

### DIFF
--- a/crates/crabe_decision/src/action/move_to.rs
+++ b/crates/crabe_decision/src/action/move_to.rs
@@ -18,6 +18,7 @@ pub struct MoveTo {
     charge: bool,
     dribbler: f32,
     kicker: Option<Kick>,
+    overshoot: bool,
 }
 
 impl From<&mut MoveTo> for MoveTo {
@@ -29,6 +30,7 @@ impl From<&mut MoveTo> for MoveTo {
             charge: other.charge,
             dribbler: other.dribbler,
             kicker: other.kicker,
+            overshoot: other.overshoot,
         }
     }
 }
@@ -46,6 +48,7 @@ impl MoveTo {
         dribbler: f32,
         charge: bool,
         kicker: Option<Kick>,
+        overshoot: bool,
     ) -> Self {
         Self {
             state: State::Running,
@@ -54,6 +57,7 @@ impl MoveTo {
             charge,
             dribbler,
             kicker,
+            overshoot,
         }
     }
 }
@@ -84,6 +88,8 @@ const GOTO_SPEED: f64 = 1.5;
 const GOTO_ROTATION: f64 = 1.5;
 /// The error tolerance for arriving at the target position.
 const ERR_TOLERANCE: f64 = 0.115;
+/// The overshoot distance.
+const OVERSHOOT_DIST: f64 = 2.;
 
 impl Action for MoveTo {
     /// Returns the name of the action.
@@ -108,8 +114,12 @@ impl Action for MoveTo {
         if let Some(robot) = world.allies_bot.get(&id) {
             let ti = frame_inv(robot_frame(robot));
             let target_in_robot = ti * Point2::new(self.target.x, self.target.y);
+            let target_overshooted = target_in_robot * OVERSHOOT_DIST;
 
             let error_orientation = angle_wrap(self.orientation - robot.pose.orientation);
+
+            let error_x_overshooted = target_overshooted.x;
+            let error_y_overshooted = target_overshooted.y;
             let error_x = target_in_robot[0];
             let error_y = target_in_robot[1];
             let arrived = Vector3::new(error_x, error_y, error_orientation).norm() < ERR_TOLERANCE;
@@ -118,8 +128,8 @@ impl Action for MoveTo {
             }
 
             let order = Vector3::new(
-                GOTO_SPEED * error_x,
-                GOTO_SPEED * error_y,
+                GOTO_SPEED * error_x_overshooted,
+                GOTO_SPEED * error_y_overshooted,
                 GOTO_ROTATION * error_orientation,
             );
 
@@ -130,6 +140,7 @@ impl Action for MoveTo {
                 charge: self.charge,
                 kick: self.kicker,
                 dribbler: self.dribbler,
+                overshoot: self.overshoot,
             }
         } else {
             Command::default()

--- a/crates/crabe_decision/src/action/move_to.rs
+++ b/crates/crabe_decision/src/action/move_to.rs
@@ -127,11 +127,20 @@ impl Action for MoveTo {
                 self.state = State::Done;
             }
 
-            let order = Vector3::new(
-                GOTO_SPEED * error_x_overshooted,
-                GOTO_SPEED * error_y_overshooted,
+            let order = 
+            if self.overshoot {
+                Vector3::new(
+                    GOTO_SPEED * error_x_overshooted,
+                    GOTO_SPEED * error_y_overshooted,
                 GOTO_ROTATION * error_orientation,
-            );
+                )
+            } else {
+                Vector3::new(
+                GOTO_SPEED * error_x,
+                GOTO_SPEED * error_y,
+                GOTO_ROTATION * error_orientation,
+                )
+            };
 
             Command {
                 forward_velocity: order.x as f32,

--- a/crates/crabe_decision/src/manager/bigbro.rs
+++ b/crates/crabe_decision/src/manager/bigbro.rs
@@ -4,7 +4,6 @@ use crate::action::ActionWrapper;
 use crate::manager::Manager;
 use crate::message::Message;
 use crate::message::MessageData;
-use crate::strategy::testing::Aligned;
 use crate::strategy::testing::GoLeftKeeper;
 use crate::strategy::testing::GoRightKeeper;
 use crate::strategy::Strategy;

--- a/crates/crabe_decision/src/manager/bigbro.rs
+++ b/crates/crabe_decision/src/manager/bigbro.rs
@@ -5,8 +5,8 @@ use crate::manager::Manager;
 use crate::message::Message;
 use crate::message::MessageData;
 use crate::strategy::testing::Aligned;
-use crate::strategy::testing::GoLeft;
-use crate::strategy::testing::GoRight;
+use crate::strategy::testing::GoLeftKeeper;
+use crate::strategy::testing::GoRightKeeper;
 use crate::strategy::Strategy;
 use crabe_framework::data::tool::ToolData;
 use crabe_framework::data::world::World;
@@ -27,8 +27,7 @@ impl BigBro {
     pub fn new() -> Self {
         Self {
             strategies: vec![
-                Box::new(GoLeft::new(1)),
-                Box::new(Aligned::new(vec![2, 3, 4])),
+                Box::new(GoLeftKeeper::new(0)),
             ],
         }
     }
@@ -84,22 +83,13 @@ impl BigBro {
     pub fn process_messages(&mut self, messages: Vec<MessageData>) {
         messages.iter().for_each(|m| {
             match m.message {
-                Message::WantToGoRight => {
-                    let strategy = Box::new(GoRight::new(m.id));
+                Message::WantToGoRightKeeper => {
+                    let strategy = Box::new(GoRightKeeper::new(m.id));
                     self.move_bot_to_new_strategy(m.id, strategy);
                 }
-                Message::WantToGoLeft => {
-                    let strategy = Box::new(GoLeft::new(m.id));
+                Message::WantToGoLeftKeeper => {
+                    let strategy = Box::new(GoLeftKeeper::new(m.id));
                     self.move_bot_to_new_strategy(m.id, strategy);
-                }
-                Message::WantToBeAligned => {
-                    //find strategy index with name "Aligned"
-                    let strategy_index = self
-                        .strategies
-                        .iter()
-                        .position(|s| s.name() == "Aligned")
-                        .unwrap();
-                    self.move_bot_to_existing_strategy(m.id, strategy_index);
                 }
                 _ => {}
             }

--- a/crates/crabe_decision/src/message.rs
+++ b/crates/crabe_decision/src/message.rs
@@ -4,6 +4,8 @@ pub enum Message {
     WantToGoRight = 0,
     WantToGoLeft = 1,
     WantToBeAligned = 2,
+    WantToGoRightKeeper = 3,
+    WantToGoLeftKeeper = 4,
 }
 
 // Data type to share information from the bot to the manager

--- a/crates/crabe_decision/src/strategy/testing.rs
+++ b/crates/crabe_decision/src/strategy/testing.rs
@@ -10,3 +10,10 @@ mod go_right;
 pub use self::go_right::GoRight;
 mod aligned;
 pub use self::aligned::Aligned;
+mod goal_line;
+pub use self::goal_line::GoalLine;
+
+mod go_left_keeper;
+pub use self::go_left_keeper::GoLeftKeeper;
+mod go_right_keeper;
+pub use self::go_right_keeper::GoRightKeeper;

--- a/crates/crabe_decision/src/strategy/testing/aligned.rs
+++ b/crates/crabe_decision/src/strategy/testing/aligned.rs
@@ -50,7 +50,7 @@ impl Strategy for Aligned {
             action_wrapper.clear(*id);
             let offset = 0.15 * ((self.ids.len() as f64) - 1.);
             let dest = Point2::new((i as f64) * 0.3 - offset, 2.0);
-            action_wrapper.push(*id, MoveTo::new(dest, -PI / 4.0, 0.0, false, None));
+            action_wrapper.push(*id, MoveTo::new(dest, -PI / 4.0, 0.0, false, None, false));
             if *id == 1 {
                 match world.allies_bot.get(id) {
                     Some(bot) => {

--- a/crates/crabe_decision/src/strategy/testing/go_left.rs
+++ b/crates/crabe_decision/src/strategy/testing/go_left.rs
@@ -49,7 +49,7 @@ impl Strategy for GoLeft {
         self.messages.clear();
         action_wrapper.push(
             self.id,
-            MoveTo::new(dest, -PI / 4.0, 0.0, false, None),
+            MoveTo::new(dest, -PI / 4.0, 0.0, false, None, false),
         );
         match world.allies_bot.get(&self.id) {
             Some(bot) => {  

--- a/crates/crabe_decision/src/strategy/testing/go_left_keeper.rs
+++ b/crates/crabe_decision/src/strategy/testing/go_left_keeper.rs
@@ -1,0 +1,65 @@
+use crate::action::move_to::MoveTo;
+use crate::action::ActionWrapper;
+use crate::strategy::Strategy;
+use crate::message::MessageData;
+use crate::message::Message;
+use crabe_framework::data::tool::ToolData;
+use crabe_framework::data::world::World;
+use nalgebra::Point2;
+
+#[derive(Default)]
+pub struct GoLeftKeeper {
+    id: u8,
+    messages: Vec<MessageData>,
+}
+
+impl GoLeftKeeper {
+    /// Creates a new GoLeft instance with the desired robot id.
+    pub fn new(id: u8) -> Self {
+        Self { id, messages: vec![]}
+    }
+}
+
+impl Strategy for GoLeftKeeper {
+    fn name(&self) -> &'static str {
+        "GoLeft"
+    }
+
+    fn get_messages(&self) -> &Vec<MessageData> {
+        &self.messages
+    }   
+    fn get_ids(&self) -> Vec<u8> {
+        vec![self.id]
+    }
+    fn put_ids(&mut self, ids: Vec<u8>) {
+        if ids.len() == 1{
+            self.id = ids[0];
+        }
+    }
+    #[allow(unused_variables)]
+    fn step(
+        &mut self,
+        world: &World,
+        tools_data: &mut ToolData,
+        action_wrapper: &mut ActionWrapper,
+    ) -> bool {
+        action_wrapper.clear(self.id);
+        let dest = Point2::new(-4.5, 0.5);
+        self.messages.clear();
+        action_wrapper.push(
+            self.id,
+            MoveTo::new(dest, 0.0, 0.0, false, None, true),
+        );
+        match world.allies_bot.get(&self.id) {
+            Some(bot) => {  
+                let bot_position = bot.pose.position;
+                let dist = (bot_position - dest).norm();
+                if dist < 0.1 {
+                    self.messages.push(MessageData::new(Message::WantToGoRightKeeper, self.id));
+                }
+            }
+            None => {}
+        }
+        false
+    }
+}

--- a/crates/crabe_decision/src/strategy/testing/go_right.rs
+++ b/crates/crabe_decision/src/strategy/testing/go_right.rs
@@ -49,7 +49,7 @@ impl Strategy for GoRight {
         self.messages.clear();
         action_wrapper.push(
             self.id,
-            MoveTo::new(dest, -PI / 4.0, 0.0, false, None),
+            MoveTo::new(dest, -PI / 4.0, 0.0, false, None, false),
         );
         match world.allies_bot.get(&self.id) {
             Some(bot) => {  

--- a/crates/crabe_decision/src/strategy/testing/go_right_keeper.rs
+++ b/crates/crabe_decision/src/strategy/testing/go_right_keeper.rs
@@ -6,7 +6,6 @@ use crate::message::Message;
 use crabe_framework::data::tool::ToolData;
 use crabe_framework::data::world::World;
 use nalgebra::Point2;
-use std::f64::consts::PI;
 
 #[derive(Default)]
 pub struct GoRightKeeper {

--- a/crates/crabe_decision/src/strategy/testing/go_right_keeper.rs
+++ b/crates/crabe_decision/src/strategy/testing/go_right_keeper.rs
@@ -1,0 +1,66 @@
+use crate::action::move_to::MoveTo;
+use crate::action::ActionWrapper;
+use crate::strategy::Strategy;
+use crate::message::MessageData;
+use crate::message::Message;
+use crabe_framework::data::tool::ToolData;
+use crabe_framework::data::world::World;
+use nalgebra::Point2;
+use std::f64::consts::PI;
+
+#[derive(Default)]
+pub struct GoRightKeeper {
+    id: u8,
+    messages: Vec<MessageData>,
+}
+
+impl GoRightKeeper {
+    /// Creates a new GoRightKeeper instance with the desired robot id.
+    pub fn new(id: u8) -> Self {
+        Self { id, messages: vec![]}
+    }
+}
+
+impl Strategy for GoRightKeeper {
+    fn name(&self) -> &'static str {
+        "GoRight"
+    }
+
+    fn get_messages(&self) -> &Vec<MessageData> {
+        &self.messages
+    }   
+    fn get_ids(&self) -> Vec<u8> {
+        vec![self.id]
+    }
+    fn put_ids(&mut self, ids: Vec<u8>) {
+        if ids.len() == 1{
+            self.id = ids[0];
+        }
+    }
+    #[allow(unused_variables)]
+    fn step(
+        &mut self,
+        world: &World,
+        tools_data: &mut ToolData,
+        action_wrapper: &mut ActionWrapper,
+    ) -> bool {
+        action_wrapper.clear(self.id);
+        let dest = Point2::new(-4.5, -0.5);
+        self.messages.clear();
+        action_wrapper.push(
+            self.id,
+            MoveTo::new(dest, 0.0, 0.0, false, None, true),
+        );
+        match world.allies_bot.get(&self.id) {
+            Some(bot) => {  
+                let bot_position = bot.pose.position;
+                let dist = (bot_position - dest).norm();
+                if dist < 0.1 {
+                    self.messages.push(MessageData::new(Message::WantToGoLeftKeeper, self.id));
+                }
+            }
+            None => {}
+        }
+        false
+    }
+}

--- a/crates/crabe_decision/src/strategy/testing/goal_line.rs
+++ b/crates/crabe_decision/src/strategy/testing/goal_line.rs
@@ -5,10 +5,8 @@ use crate::message::MessageData;
 use crabe_framework::data::tool::ToolData;
 use crabe_framework::data::world::World;
 use nalgebra::Point2;
-use std::f64::consts::PI;
 
-/// The GoalLine struct represents a strategy that commands a robot to move in a GoalLine shape
-/// in a counter-clockwise. It is used for testing purposes.
+/// The GoalLine struct represents a strategy that commands a robot to move in the GoalLine
 #[derive(Default)]
 pub struct GoalLine {
     /// The id of the robot to move.
@@ -41,8 +39,7 @@ impl Strategy for GoalLine {
     }
     /// Executes the GoalLine strategy.
     ///
-    /// This strategy commands the robot with the specified ID to move in a GoalLine shape in a
-    /// counter-clockwise direction.
+    /// This strategy commands the robot with the specified ID to move in the GoalLine
     ///
     /// # Arguments
     ///

--- a/crates/crabe_decision/src/strategy/testing/goal_line.rs
+++ b/crates/crabe_decision/src/strategy/testing/goal_line.rs
@@ -1,0 +1,73 @@
+use crate::action::move_to::MoveTo;
+use crate::action::ActionWrapper;
+use crate::strategy::Strategy;
+use crate::message::MessageData;
+use crabe_framework::data::tool::ToolData;
+use crabe_framework::data::world::World;
+use nalgebra::Point2;
+use std::f64::consts::PI;
+
+/// The GoalLine struct represents a strategy that commands a robot to move in a GoalLine shape
+/// in a counter-clockwise. It is used for testing purposes.
+#[derive(Default)]
+pub struct GoalLine {
+    /// The id of the robot to move.
+    id: u8,
+    messages: Vec<MessageData>,
+}
+
+impl GoalLine {
+    /// Creates a new GoalLine instance with the desired robot id.
+    pub fn new(id: u8) -> Self {
+        Self { id, messages: vec![]}
+    }
+}
+
+impl Strategy for GoalLine {
+    fn name(&self) -> &'static str {
+        "GoalLine"
+    }
+
+    fn get_messages(&self) -> &Vec<MessageData> {
+        &self.messages
+    }
+    fn get_ids(&self) -> Vec<u8> {
+        vec![self.id]
+    }
+    fn put_ids(&mut self, ids: Vec<u8>) {
+        if ids.len() == 1{
+            self.id = ids[0];
+        }
+    }
+    /// Executes the GoalLine strategy.
+    ///
+    /// This strategy commands the robot with the specified ID to move in a GoalLine shape in a
+    /// counter-clockwise direction.
+    ///
+    /// # Arguments
+    ///
+    /// * world: The current state of the game world.
+    /// * tools_data: A collection of external tools used by the strategy, such as a viewer.    
+    /// * action_wrapper: An `ActionWrapper` instance used to issue actions to the robot.
+    ///
+    /// # Returns
+    ///
+    /// A boolean value indicating whether the strategy is finished or not.
+    #[allow(unused_variables)]
+    fn step(
+        &mut self,
+        world: &World,
+        tools_data: &mut ToolData,
+        action_wrapper: &mut ActionWrapper,
+    ) -> bool {
+        action_wrapper.push(
+            self.id,
+            MoveTo::new(Point2::new(-4.5, 0.5), 0.0, 0.0, false, None, true),
+        );
+        action_wrapper.push(
+            self.id,
+            MoveTo::new(Point2::new(-4.5, -0.5), 0.0, 0.0, false, None, true),
+        );
+        true
+    }
+}

--- a/crates/crabe_decision/src/strategy/testing/square.rs
+++ b/crates/crabe_decision/src/strategy/testing/square.rs
@@ -62,19 +62,19 @@ impl Strategy for Square {
     ) -> bool {
         action_wrapper.push(
             self.id,
-            MoveTo::new(Point2::new(-1.0, 1.0), -PI / 4.0, 0.0, false, None),
+            MoveTo::new(Point2::new(-1.0, 1.0), -PI / 4.0, 0.0, false, None, false),
         );
         action_wrapper.push(
             self.id,
-            MoveTo::new(Point2::new(1.0, 1.0), -3.0 * PI / 4.0, 0.0, false, None),
+            MoveTo::new(Point2::new(1.0, 1.0), -3.0 * PI / 4.0, 0.0, false, None, false),
         );
         action_wrapper.push(
             self.id,
-            MoveTo::new(Point2::new(1.0, -1.0), 3.0 * PI / 4.0, 0.0, false, None),
+            MoveTo::new(Point2::new(1.0, -1.0), 3.0 * PI / 4.0, 0.0, false, None, false),
         );
         action_wrapper.push(
             self.id,
-            MoveTo::new(Point2::new(-1.0, -1.0), PI / 4.0, 0.0, false, None),
+            MoveTo::new(Point2::new(-1.0, -1.0), PI / 4.0, 0.0, false, None, false),
         );
         true
     }

--- a/crates/crabe_filter/src/post_filter/geometry.rs
+++ b/crates/crabe_filter/src/post_filter/geometry.rs
@@ -130,7 +130,6 @@ fn geometry_to_penalty(cam_geometry: &CamGeometry, positive: bool) -> Penalty {
 
 fn geometry_to_goal(cam_geometry: &CamGeometry, positive: bool) -> Goal {
     let factor = if positive { 1.0 } else { -1.0 };
-    println!("cam_geometry.goal_width: {}", cam_geometry.goal_width);
     Goal {
         width: cam_geometry.goal_width,
         depth: cam_geometry.goal_depth,

--- a/crates/crabe_framework/src/data/output.rs
+++ b/crates/crabe_framework/src/data/output.rs
@@ -43,4 +43,6 @@ pub struct Command {
     pub kick: Option<Kick>,
     /// Dribbler speed in rounds per minute rpm
     pub dribbler: f32,
+    /// Order to overshoot the target
+    pub overshoot: bool,
 }


### PR DESCRIPTION
I added a paremeter to move to to make so that we can set a robot to overshoot his target.
In order to make the robot arrive faster at the target without slowing down too early, I also implemented an strategy to test it, goal_line, with bigbro. Make sure to test it if you want.

I've changed the parameters in the moveTo of the existing strategies to set overshoot to false.

To change the overshooting distance just increase or decrease the multiplier of overshoot called OVERSHOOT_DIST in the move_to.rs file.